### PR TITLE
Run dask's shuffle tests in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9"]
         # Cherry-pick test modules to split the overall runtime roughly in half
-        partition: [ci1, not ci1]
+        partition: [ci1, not ci1, dask_shuffle]
 
         # Uncomment to stress-test the test suite for random failures.
         # Must also change env.TEST_ID below.

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -44,6 +44,6 @@ dependencies:
   - zict
   - zstandard
   - pip:
-      - git+https://github.com/dask/dask
+      - git+https://github.com/gjoseph92/dask@p2p-shuffle-draft
       - git+https://github.com/jcrist/crick  # Only tested here
       - keras

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -42,5 +42,5 @@ dependencies:
   - zict
   - zstandard
   - pip:
-      - git+https://github.com/dask/dask
+      - git+https://github.com/gjoseph92/dask@p2p-shuffle-draft
       - keras

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -49,7 +49,7 @@ dependencies:
   - zict  # overridden by git tip below
   - zstandard
   - pip:
-      - git+https://github.com/dask/dask
+      - git+https://github.com/gjoseph92/dask@p2p-shuffle-draft
       - git+https://github.com/dask/s3fs
       - git+https://github.com/dask/zict
       # FIXME https://github.com/dask/distributed/issues/5345

--- a/distributed/shuffle/tests/dask_tests/conftest.py
+++ b/distributed/shuffle/tests/dask_tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+import dask
+
+
+@pytest.fixture(scope="module")
+def shuffle_method():
+    with dask.config.set(shuffle="p2p"):
+        from distributed import Client
+        from distributed.utils_test import cluster
+
+        with cluster(worker_kwargs={"nthreads": 2}) as (scheduler, _):
+            with Client(scheduler["address"]):
+                yield "p2p"

--- a/distributed/shuffle/tests/dask_tests/test_groupby.py
+++ b/distributed/shuffle/tests/dask_tests/test_groupby.py
@@ -1,0 +1,1 @@
+from dask.dataframe.tests.test_groupby import *  # noqa

--- a/distributed/shuffle/tests/dask_tests/test_groupby.py
+++ b/distributed/shuffle/tests/dask_tests/test_groupby.py
@@ -1,1 +1,5 @@
+import pytest
+
 from dask.dataframe.tests.test_groupby import *  # noqa
+
+pytestmark = pytest.mark.dask_shuffle

--- a/distributed/shuffle/tests/dask_tests/test_multi.py
+++ b/distributed/shuffle/tests/dask_tests/test_multi.py
@@ -1,0 +1,1 @@
+from dask.dataframe.tests.test_multi import *  # noqa

--- a/distributed/shuffle/tests/dask_tests/test_multi.py
+++ b/distributed/shuffle/tests/dask_tests/test_multi.py
@@ -1,1 +1,5 @@
+import pytest
+
 from dask.dataframe.tests.test_multi import *  # noqa
+
+pytestmark = pytest.mark.dask_shuffle

--- a/distributed/shuffle/tests/dask_tests/test_shuffle.py
+++ b/distributed/shuffle/tests/dask_tests/test_shuffle.py
@@ -1,1 +1,5 @@
+import pytest
+
 from dask.dataframe.tests.test_shuffle import *  # noqa
+
+pytestmark = pytest.mark.dask_shuffle

--- a/distributed/shuffle/tests/dask_tests/test_shuffle.py
+++ b/distributed/shuffle/tests/dask_tests/test_shuffle.py
@@ -1,0 +1,1 @@
+from dask.dataframe.tests.test_shuffle import *  # noqa


### PR DESCRIPTION
Run many tests from dask/dask in distributed's CI against the new P2P shuffle. Currently this runs all of `test_shuffle`, `test_groupby`, and `test_multi`.

* Requires https://github.com/dask/dask/pull/8392 (changes to `assert_eq`/some tests to make them actually use the P2P shuffle)
* Branched off of https://github.com/dask/distributed/pull/5524
* Uses @ian-r-rose's work in https://github.com/dask/dask/pull/8250

I put the shuffle tests in their own CI job by just extending the `ci1`/`not ci1` matrix. It looks like it takes 9-12min to run them _reusing the same cluster for every test_. If I removed `scope="module"`, I imagine it would be much, much slower.

This isn't how we'd want to implement it for real, just trying this to get a sense of runtimes. If we actually did it, we'd want to collect every test using the `shuffle_method` fixture (this currently both misses some tests, and runs some extraneous tests that don't use the fixture). The pytest-within-pytest incantations did not seem worth figuring out yet, since I'm not sure if we'll want to use this approach at all.

So this indicates running the `dask/dask` tests in distributed would be possible, though maybe not a good idea.

cc @fjetter