### PR TITLE
Priority families

### DIFF
--- a/distributed/families.py
+++ b/distributed/families.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import operator
+from typing import TYPE_CHECKING, Collection, Iterator
+
+if TYPE_CHECKING:
+    from distributed.scheduler import TaskState
+
+prio_getter = operator.attrgetter("priority")
+
+
+def group_by_family(
+    tasks: Collection[TaskState],
+) -> Iterator[tuple[list[TaskState], bool]]:
+    tasks = sorted(tasks, key=prio_getter)
+    family_start_i = 0
+    while family_start_i < len(tasks):
+        ts = tasks[family_start_i]
+        prev_prio = start_prio = ts.priority[-1]
+        max_prio = prev_prio + 1
+        proper_family: bool = False
+        while ts.dependents:
+            ts = min(ts.dependents, key=prio_getter)
+            max_prio = ts.priority[-1]
+            if max_prio == prev_prio + 1:
+                # walk linear chains of consecutive priority
+                # TODO if this chain is all linear, try again from the start with the next-smallest dependent
+                prev_prio = max_prio
+            else:
+                # non-consecutive priority jump. this is our max node.
+                prev_prio = max_prio
+                proper_family = True
+                assert max_prio > start_prio + 1, (max_prio, start_prio, ts)
+                break
+
+        # all tasks from the start to the max (inclusive) belong to the family.
+        next_start_i = family_start_i + (max_prio - start_prio) + 1
+        yield tasks[family_start_i:next_start_i], proper_family
+        family_start_i = next_start_i

--- a/distributed/tests/test_scheduler_family.py
+++ b/distributed/tests/test_scheduler_family.py
@@ -6,7 +6,8 @@ from tlz import partition, partition_all
 
 import dask
 
-from distributed.scheduler import family
+from distributed.families import group_by_family
+from distributed.scheduler import TaskState
 from distributed.utils_test import async_wait_for, gen_cluster, slowidentity, slowinc
 
 ident = dask.delayed(slowidentity, pure=True)
@@ -28,8 +29,22 @@ async def submit_delayed(client, scheduler, x):
     return fs
 
 
+_ = TaskState("_", None, "released")
+
+
+def assert_family(
+    family: tuple[list[TaskState], bool], pattern: list[TaskState], *, proper: bool
+) -> None:
+    fam, is_proper = family
+    assert is_proper == proper
+    assert len(fam) == len(pattern)
+    for f, p in zip(fam, pattern):
+        if p is not _:
+            assert f is p
+
+
 @gen_cluster(nthreads=[], client=True)
-async def test_family(c, s):
+async def test_family_two_step_reduction(c, s):
     r"""
           z         z         z
         /  |      /  |      /  |
@@ -41,39 +56,29 @@ async def test_family(c, s):
     bx = [dask.delayed(i, name=f"b-{i}") for i in range(3)]
     cx = [dask.delayed(i, name=f"c-{i}") for i in range(3)]
 
-    zs = [(a + b) + c for a, b, c in zip(ax, bx, cx)]
+    zs = [
+        add(add(a, b, dask_key_name=f"x-{i}"), c, dask_key_name=f"z-{i}")
+        for i, (a, b, c) in enumerate(zip(ax, bx, cx))
+    ]
 
     _ = await submit_delayed(c, s, zs)
 
-    a1 = s.tasks["a-1"]
-    b1 = s.tasks["b-1"]
-    c1 = s.tasks["c-1"]
+    fams = list(group_by_family(s.tasks.values()))
+    assert len(fams) == 6
 
-    fam = family(a1, 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {b1}
-    assert len(downstream) == 1
-    add_1_1 = next(iter(downstream))
+    for i, [f0, f1] in enumerate(partition(2, fams)):
+        a = s.tasks[f"a-{i}"]
+        b = s.tasks[f"b-{i}"]
+        x = s.tasks[f"x-{i}"]
+        c = s.tasks[f"c-{i}"]
+        z = s.tasks[f"z-{i}"]
 
-    fam = family(c1, 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {add_1_1}
-    assert len(downstream) == 1  # don't know keys
-    add_1_2 = next(iter(downstream))
-
-    fam = family(add_1_1, 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {c1}
-    assert downstream == {add_1_2}
-
-    assert family(add_1_2, 1000, 1000) is None
+        assert_family(f0, [a, b, x], proper=True)
+        assert_family(f1, [c, z], proper=False)
 
 
 @gen_cluster(nthreads=[], client=True)
-async def test_family_linear_chains(c, s):
+async def test_family_two_step_reduction_linear_chains(c, s):
     r"""
                           final
                      /              \               \
@@ -114,63 +119,31 @@ async def test_family_linear_chains(c, s):
 
     _ = await submit_delayed(c, s, final)
 
-    root = s.tasks["root"]
-    a1 = s.tasks["a-1"]
-    b1 = s.tasks["b-1"]
-    c1 = s.tasks["c-1"]
-    d1 = s.tasks["d-1"]
-    s1_1 = s.tasks["s1-1"]
-    s2_1 = s.tasks["s2-1"]
-    final = s.tasks["final"]
+    fams = list(group_by_family(s.tasks.values()))
+    assert len(fams) == 8
 
-    await async_wait_for(lambda: final.state == "waiting", 5)
+    st = s.tasks
+    root = st["root"]
+    final = st["final"]
 
-    # `a` traverses chains up and down to find `b` and `c`
-    # Does *not* include `d`: `d` is not required to compute `s1`
-    fam = family(a1, 1000, 4)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {b1, c1}
-    assert downstream == {s1_1}
+    assert_family(fams[0], [root], proper=False)
 
-    # `d` traverses chains up to find `s2`
-    # does not traverse down past `s2`
-    fam = family(d1, 1000, 4)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {s1_1}
-    assert downstream == {s2_1}
+    assert_family(
+        fams[1], [st["a-0"], _, _, st["b-0"], st["c-0"], _, st["s1-0"]], proper=True
+    )
+    assert_family(fams[2], [st["d-0"], _, st["s2-0"]], proper=True)
 
-    # Don't traverse a linear chain past self
-    mid_chain = next(iter(a1.dependents))
-    fam = family(mid_chain, 1000, 4)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {b1, c1}
-    assert downstream == {s1_1}
+    assert_family(
+        fams[3], [st["a-1"], _, _, st["b-1"], st["c-1"], _, st["s1-1"]], proper=True
+    )
+    assert_family(fams[4], [st["d-1"], _, st["s2-1"]], proper=True)
 
-    # `root` has no family with small widely-shared cutoff
-    assert family(root, 1000, 4) is None
+    assert_family(
+        fams[5], [st["a-2"], _, _, st["b-2"], st["c-2"], _, st["s1-2"]], proper=True
+    )
+    assert_family(fams[6], [st["d-2"], _, st["s2-2"]], proper=True)
 
-    # With large cutoff, `root` has no siblings.
-    # But the `s1` and `s2` tasks are all considered downstream, if you
-    # collapse the linear chains (which include `a`, `b`, `c`, `d`).
-
-    # Note that `s1`s could be considered both siblings and downstreams
-    # (siblings, since they need to be in memory along with root to compute `s2`).
-    # But tasks that meet this criteria are explicitly labeled as only downstream.
-    fam = family(root, 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == set()
-    assert {ts.key for ts in downstream} == {
-        "s1-0",
-        "s1-1",
-        "s1-2",
-        "s2-0",
-        "s2-1",
-        "s2-2",
-    }
+    assert_family(fams[7], [final], proper=False)
 
 
 @gen_cluster(nthreads=[], client=True)
@@ -192,169 +165,180 @@ async def test_family_linear_chains_plus_widely_shared(c, s):
 
     _ = await submit_delayed(c, s, sx)
 
-    r0 = s.tasks["r-0"]
-    r1 = s.tasks["r-1"]
-    r2 = s.tasks["r-2"]
-    s0 = s.tasks["s-0"]
+    fams = list(group_by_family(s.tasks.values()))
+    assert len(fams) == 4
 
-    fam = family(r0, 1000, 4)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {r1, r2}
-    assert downstream == {s0}
+    st = s.tasks
 
-
-@gen_cluster(nthreads=[], client=True)
-async def test_family_triangle(c, s):
-    r"""
-      z
-     /|
-    y |
-    \ |
-      x
-    """
-    x = dask.delayed(0, name="x")
-    y = inc(x, dask_key_name="y")
-    z = add(x, y, dask_key_name="z")
-
-    _ = await submit_delayed(c, s, z)
-
-    x = s.tasks["x"]
-    y = s.tasks["y"]
-    z = s.tasks["z"]
-
-    fam = family(x, 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == set()
-    assert downstream == {z}  # `y` is just a linear chain, not downstream
-
-    fam = family(y, 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {x}
-    assert downstream == {z}
+    assert_family(fams[0], [st["shared"]], proper=False)
+    assert_family(
+        fams[1],
+        [st["r-0"], st["a-0"], st["r-1"], st["a-1"], st["r-2"], st["a-2"], st["s-0"]],
+        proper=True,
+    )
+    assert_family(
+        fams[2],
+        [st["r-3"], st["a-3"], st["r-4"], st["a-4"], st["r-5"], st["a-5"], st["s-1"]],
+        proper=True,
+    )
+    assert_family(
+        fams[3],
+        [st["r-6"], st["a-6"], st["r-7"], st["a-7"], st["s-3"]],
+        proper=True,
+    )
 
 
-@gen_cluster(nthreads=[], client=True)
-async def test_family_wide_gather_downstream(c, s):
-    r"""
-            s
-     / / / /|\ \ \
-    i i i i i i i i
-    | | | | | | | |
-    r r r r r r r r
-    """
-    roots = [dask.delayed(i, name=f"r-{i}") for i in range(8)]
-    incs = [inc(r, dask_key_name=f"i-{i}") for i, r in enumerate(roots)]
-    sum = dsum(incs, dask_key_name="sum")
+# @gen_cluster(nthreads=[], client=True)
+# async def test_family_triangle(c, s):
+#     r"""
+#       z
+#      /|
+#     y |
+#     \ |
+#       x
+#     """
+#     x = dask.delayed(0, name="x")
+#     y = inc(x, dask_key_name="y")
+#     z = add(x, y, dask_key_name="z")
 
-    _ = await submit_delayed(c, s, sum)
+#     _ = await submit_delayed(c, s, z)
 
-    rts = [s.tasks[r.key] for r in roots]
-    sts = s.tasks["sum"]
+#     x = s.tasks["x"]
+#     y = s.tasks["y"]
+#     z = s.tasks["z"]
 
-    fam = family(rts[0], 4, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == set()
-    assert downstream == set()  # `sum` not downstream because it's too large
+#     fam = family(x, 1000, 1000)
+#     assert fam
+#     sibs, downstream = fam
+#     assert sibs == set()
+#     assert downstream == {z}  # `y` is just a linear chain, not downstream
 
-    fam = family(rts[0], 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == set(rts[1:])
-    assert downstream == {sts}
-
-
-# TODO test family commutativity. Given any node X in any graph, calculate `family(X)`.
-# For each sibling S, `family(S)` should give the same family, regardless of the
-# starting node.
-# EXECPT THIS ISN'T TRUE
+#     fam = family(y, 1000, 1000)
+#     assert fam
+#     sibs, downstream = fam
+#     assert sibs == {x}
+#     assert downstream == {z}
 
 
-@gen_cluster(nthreads=[], client=True)
-async def test_family_non_commutative(c, s):
-    roots = [dask.delayed(i, name=f"r-{i}") for i in range(16)]
-    aggs = [dsum(rs) for rs in partition(4, roots)]
-    extra = dsum([roots[::4]], dask_key_name="extra")
+# @gen_cluster(nthreads=[], client=True)
+# async def test_family_wide_gather_downstream(c, s):
+#     r"""
+#             s
+#      / / / /|\ \ \
+#     i i i i i i i i
+#     | | | | | | | |
+#     r r r r r r r r
+#     """
+#     roots = [dask.delayed(i, name=f"r-{i}") for i in range(8)]
+#     incs = [inc(r, dask_key_name=f"i-{i}") for i, r in enumerate(roots)]
+#     sum = dsum(incs, dask_key_name="sum")
 
-    _ = await submit_delayed(c, s, aggs + [extra])
+#     _ = await submit_delayed(c, s, sum)
 
-    rts = [s.tasks[r.key] for r in roots]
-    ats = [s.tasks[a.key] for a in aggs]
-    ets = s.tasks["extra"]
+#     rts = [s.tasks[r.key] for r in roots]
+#     sts = s.tasks["sum"]
 
-    fam = family(rts[0], 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == set(rts[1:4]) | {rts[4], rts[8], rts[12]}
-    assert downstream == {ats[0], ets}
+#     fam = family(rts[0], 4, 1000)
+#     assert fam
+#     sibs, downstream = fam
+#     assert sibs == set()
+#     assert downstream == set()  # `sum` not downstream because it's too large
 
-    fam = family(rts[1], 1000, 1000)
-    assert fam
-    sibs, downstream = fam
-    assert sibs == {rts[0], rts[2], rts[3]}
-    assert downstream == {ats[0]}
-
-
-@gen_cluster(nthreads=[], client=True)
-async def test_reuse(c, s):
-    r"""
-    a + (a + 1).mean()
-    """
-    roots = [dask.delayed(i, name=f"r-{i}") for i in range(6)]
-    incs = [inc(r, name=f"i-{i}") for i, r in enumerate(roots)]
-    mean = dsum([dsum(incs[:3]), dsum(incs[3:])])
-    deltas = [add(r, mean, dask_key_name=f"d-{i}") for i, r in enumerate(roots)]
-
-    _ = await submit_delayed(c, s, deltas)
+#     fam = family(rts[0], 1000, 1000)
+#     assert fam
+#     sibs, downstream = fam
+#     assert sibs == set(rts[1:])
+#     assert downstream == {sts}
 
 
-@gen_cluster(nthreads=[], client=True)
-async def test_common_with_trees(c, s):
-    r"""
-     x       x        x      x
-     /|\    /|\      /|\    /|\
-    a | b  c | d    e | f  g | h
-      |      |        |      |
-       ---------- c ----------
-    """
-    pass
+# # TODO test family commutativity. Given any node X in any graph, calculate `family(X)`.
+# # For each sibling S, `family(S)` should give the same family, regardless of the
+# # starting node.
+# # EXECPT THIS ISN'T TRUE
 
 
-@gen_cluster(nthreads=[], client=True)
-async def test_zigzag(c, s):
-    r"""
-    x  x  x  x
-    | /| /| /|
-    r  r  r  r
-    """
-    roots = [dask.delayed(i, name=f"r-{i}") for i in range(4)]
-    others = [
-        inc(roots[0]),
-        add(roots[0], roots[1]),
-        add(roots[1], roots[2]),
-        add(roots[2], roots[3]),
-    ]
+# @gen_cluster(nthreads=[], client=True)
+# async def test_family_non_commutative(c, s):
+#     roots = [dask.delayed(i, name=f"r-{i}") for i in range(16)]
+#     aggs = [dsum(rs) for rs in partition(4, roots)]
+#     extra = dsum([roots[::4]], dask_key_name="extra")
 
-    _ = await submit_delayed(c, s, others)
+#     _ = await submit_delayed(c, s, aggs + [extra])
+
+#     rts = [s.tasks[r.key] for r in roots]
+#     ats = [s.tasks[a.key] for a in aggs]
+#     ets = s.tasks["extra"]
+
+#     fam = family(rts[0], 1000, 1000)
+#     assert fam
+#     sibs, downstream = fam
+#     assert sibs == set(rts[1:4]) | {rts[4], rts[8], rts[12]}
+#     assert downstream == {ats[0], ets}
+
+#     fam = family(rts[1], 1000, 1000)
+#     assert fam
+#     sibs, downstream = fam
+#     assert sibs == {rts[0], rts[2], rts[3]}
+#     assert downstream == {ats[0]}
 
 
-@gen_cluster(nthreads=[], client=True)
-async def test_overlap(c, s):
-    r"""
-    x  x  x  x
-    |\/|\/|\/|
-    |/\|/\|/\|
-    r  r  r  r
-    """
-    roots = [dask.delayed(i, name=f"r-{i}") for i in range(4)]
-    others = [
-        add(roots[0], roots[1]),
-        dsum(roots[0], roots[1], roots[2]),
-        dsum(roots[1], roots[2], roots[3]),
-        add(roots[2], roots[3]),
-    ]
+# @gen_cluster(nthreads=[], client=True)
+# async def test_reuse(c, s):
+#     r"""
+#     a + (a + 1).mean()
+#     """
+#     roots = [dask.delayed(i, name=f"r-{i}") for i in range(6)]
+#     incs = [inc(r, name=f"i-{i}") for i, r in enumerate(roots)]
+#     mean = dsum([dsum(incs[:3]), dsum(incs[3:])])
+#     deltas = [add(r, mean, dask_key_name=f"d-{i}") for i, r in enumerate(roots)]
 
-    _ = await submit_delayed(c, s, others)
+#     _ = await submit_delayed(c, s, deltas)
+
+
+# @gen_cluster(nthreads=[], client=True)
+# async def test_common_with_trees(c, s):
+#     r"""
+#      x       x        x      x
+#      /|\    /|\      /|\    /|\
+#     a | b  c | d    e | f  g | h
+#       |      |        |      |
+#        ---------- c ----------
+#     """
+#     pass
+
+
+# @gen_cluster(nthreads=[], client=True)
+# async def test_zigzag(c, s):
+#     r"""
+#     x  x  x  x
+#     | /| /| /|
+#     r  r  r  r
+#     """
+#     roots = [dask.delayed(i, name=f"r-{i}") for i in range(4)]
+#     others = [
+#         inc(roots[0]),
+#         add(roots[0], roots[1]),
+#         add(roots[1], roots[2]),
+#         add(roots[2], roots[3]),
+#     ]
+
+#     _ = await submit_delayed(c, s, others)
+
+
+# @gen_cluster(nthreads=[], client=True)
+# async def test_overlap(c, s):
+#     r"""
+#     x  x  x  x
+#     |\/|\/|\/|
+#     |/\|/\|/\|
+#     r  r  r  r
+#     """
+#     roots = [dask.delayed(i, name=f"r-{i}") for i in range(4)]
+#     others = [
+#         add(roots[0], roots[1]),
+#         dsum(roots[0], roots[1], roots[2]),
+#         dsum(roots[1], roots[2], roots[3]),
+#         add(roots[2], roots[3]),
+#     ]
+
+#     _ = await submit_delayed(c, s, others)


### PR DESCRIPTION
My initial approach implementing the ideas from #7141. Just the core co-grouping algorithm, not actually used for scheduling at all yet.

I branched this off of https://github.com/dask/distributed/pull/7076, since it might ultimately make some of the scheduling part easier, but it's not actually used here.

Haven't looked at #7141 much at all. Also not sure I implemented the algorithm correctly.
- This should be worst-case linear time
- Widely-shared deps or reductions mess up groups. See `test_family_two_step_reduction_linear_chains`.